### PR TITLE
fix: pin streamlit version to 1.42 to fix font breaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit
+streamlit==1.42
 Pillow
 groq


### PR DESCRIPTION
https://discuss.streamlit.io/t/custom-fonts-stopped-working-in-1-43/94177/2